### PR TITLE
Update ffjavascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@iden3/bigarray": "0.0.2",
     "@iden3/binfileutils": "0.0.6",
     "fastfile": "0.0.19",
-    "ffjavascript": "0.2.30"
+    "ffjavascript": "0.2.33"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
Snarkjs uses this dependency, so to fix the build step in snarkjs, we also need to update ffjavascript here.