### PR TITLE
chore: Update ffjavascript & binfileutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@iden3/bigarray": "0.0.2",
     "@iden3/binfileutils": "0.0.8",
     "fastfile": "0.0.19",
-    "ffjavascript": "0.2.39"
+    "ffjavascript": "0.2.46"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/iden3/r1csfile#readme",
   "dependencies": {
     "@iden3/bigarray": "0.0.2",
-    "@iden3/binfileutils": "0.0.8",
+    "@iden3/binfileutils": "0.0.9",
     "fastfile": "0.0.19",
     "ffjavascript": "0.2.46"
   },


### PR DESCRIPTION
This updates ffjavascript to v0.2.46 to pick up some bug fixes.

Depends on https://github.com/iden3/binfileutils/pull/3 so we can update binfileutils too.